### PR TITLE
[charts] support additionalLabels for occm serviceMonitor and cinder-csi-plugin podMonitor

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.30.0
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 2.30.1-alpha.1
+version: 2.30.1-alpha.2
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/controllerplugin-podmonitor.yaml
+++ b/charts/cinder-csi-plugin/templates/controllerplugin-podmonitor.yaml
@@ -4,6 +4,9 @@ kind: PodMonitor
 metadata:
   labels:
     {{- include "cinder-csi.controllerplugin.labels" . | nindent 4 }}
+  {{- if .Values.csi.plugin.podMonitor.additionalLabels }}
+    {{- toYaml .Values.csi.plugin.podMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
   name: {{ include "cinder-csi.name" . }}-controllerplugin
   namespace: {{ .Release.Namespace }}
   annotations:

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -136,6 +136,7 @@ csi:
     # See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PodMonitor
     podMonitor:
       enabled: false
+      additionalLabels: {}
     extraArgs: {}
     extraEnv: []
 

--- a/charts/openstack-cloud-controller-manager/Chart.yaml
+++ b/charts/openstack-cloud-controller-manager/Chart.yaml
@@ -4,7 +4,7 @@ description: Openstack Cloud Controller Manager Helm Chart
 icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
 home: https://github.com/kubernetes/cloud-provider-openstack
 name: openstack-cloud-controller-manager
-version: 2.30.2
+version: 2.30.3
 maintainers:
   - name: eumel8
     email: f.kloeker@telekom.de

--- a/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/openstack-cloud-controller-manager/templates/servicemonitor.yaml
@@ -3,7 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "occm.name" . }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: 
+    {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.commonAnnotations }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -86,6 +86,7 @@ controllerExtraArgs: {}
 serviceMonitor: {}
 # serviceMonitor:
 #   enabled: true
+#   additionalLabels: {}
 
 # Create a secret resource cloud-config (or other name) to store credentials and settings from cloudConfig
 # You can also provide your own secret (not created by the Helm chart), in this case set create to false


### PR DESCRIPTION
test chart release